### PR TITLE
upgrade to clojure 1.8.0 and incanter 1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject skm-ice/rincanter
-  "0.0.3-SNAPSHOT"
+  "0.1-SNAPSHOT"
   :description "Clojure/R integration using rosuda Rserve"
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [incanter/incanter-core "1.5.6"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [incanter/incanter-core "1.9.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.rosuda.REngine/REngine "2.1.0"]
                  [org.clojure/core.incubator "0.1.3"]

--- a/src/rincanter/convert.clj
+++ b/src/rincanter/convert.clj
@@ -141,8 +141,7 @@ otherwise"
 (defmethod from-r ::dataframe
   [dataframe]
   (if-not (dataframe? dataframe)
-    (throw IllegalArgumentException
-           "Must be R class data.frame"))
+    (throw (IllegalArgumentException. "Must be R class data.frame")))
   (let [names (from-r (r-attr dataframe "names"))
         cols (map from-r (.asList dataframe))
         col-meta (zipmap names (map meta cols))

--- a/src/rincanter/core.clj
+++ b/src/rincanter/core.clj
@@ -155,8 +155,8 @@ repository or the master CRAN repository"
   "Boot up RServe on default port in another process.
    Returns a map with a java.lang.Process that can be 'destroy'ed"
   ([] (start-rserve 6311))
-  ([port init-r]
-   (let [rstr  (format "%s ;library(Rserve); run.Rserve(args='--no-save --slave', port=%s);" init-r port)]
+  ([port]
+   (let [rstr  (format "library(Rserve); run.Rserve(args='--no-save --slave', port=%s);" port)]
      (prn rstr)
      (proc/spawn (r-path)
                  "--no-save"                                   ;; don't save workspace when quitting

--- a/src/rincanter/core.clj
+++ b/src/rincanter/core.clj
@@ -154,9 +154,14 @@ repository or the master CRAN repository"
 (defn start-rserve
   "Boot up RServe on default port in another process.
    Returns a map with a java.lang.Process that can be 'destroy'ed"
-  ([] (start-rserve 6311))
-  ([port]
-   (let [rstr  (format "library(Rserve); run.Rserve(args='--no-save --slave', port=%s);" port)]
+  ([] (start-rserve 6311 ""))
+  ([port init-r]
+   (let [rstr-temp  (format "library(Rserve); run.Rserve(args='--no-save --slave', port=%s);" port)
+         rstr (if (empty? init-r )
+                rstr-temp
+                (str init-r ";" rstr-temp )
+                )
+         ]
      (prn rstr)
      (proc/spawn (r-path)
                  "--no-save"                                   ;; don't save workspace when quitting

--- a/test/rincanter/core_test.clj
+++ b/test/rincanter/core_test.clj
@@ -85,7 +85,7 @@
   (with-r-eval
     "data(iris)"
     ;;starts off an R dataframe, turns into an incanter dataset
-    (is (= (type (r-get *R* "iris")) incanter.core.Dataset))))
+    (is (= (type (r-get *R* "iris")) clojure.core.matrix.impl.dataset.DataSet)))) ;TODO fix class
 
 (deftest dataframe-dataset-dim-equivalence
   (is (= [150 5] (r-eval *R* "dim(iris)")))
@@ -115,7 +115,7 @@
 (deftest dataframe-dataset-mean
   (with-data (r-get *R* "iris")
     (is (within 0.000001
-                 (mean ($ :Sepal.Width))
+                (mean ($ "Sepal.Width"))
                  ((r-eval *R* "mean(iris$Sepal.Width)") 0)))))
 
 (use-fixtures :once r-connection-fixture)


### PR DESCRIPTION
The way forward for incanter is the development version 1.9.0

It contains a new dataset implementation based on core.matrix.

I did some tiny code changes to make rincater compatible with it.

I had an other problem, with an empty r-nit string, so fixed taht as well

